### PR TITLE
prefsCleaner.sh: Fix invalid regular expression

### DIFF
--- a/prefsCleaner.sh
+++ b/prefsCleaner.sh
@@ -48,7 +48,7 @@ fClean() {
 		if [[ "$line" =~ $prefexp && $prefs != *"@@${BASH_REMATCH[1]}@@"* ]]; then
 			prefs="${prefs}${BASH_REMATCH[1]}@@"
 		fi
-	done <<< "$(grep -E \"$prefexp\" user.js)"
+	done <<< "$(grep -E "$prefexp" user.js)"
 
 	while IFS='' read -r line || [[ -n "$line" ]]; do
 		if [[ "$line" =~ ^$prefexp ]]; then


### PR DESCRIPTION
 #1255 Provided an incomplete fix for old shell syntax, where " quotes previously needed to be specially escaped in \` ... \` syntax but no longer need to be escaped in $( ... ) syntax.