### PR TITLE
Fix newline issue when downloading files in updater.sh

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -106,7 +106,7 @@ Optional Arguments:
 download_file() { # expects URL as argument ($1)
   declare -r tf=$(mktemp)
 
-  $DOWNLOAD_METHOD "${tf}" "$1" && echo "$tf" || echo '' # return the temp-filename or empty string on error
+  $DOWNLOAD_METHOD "${tf}" "$1" &>/dev/null && echo "$tf" || echo '' # return the temp-filename or empty string on error
 }
 
 open_file() { # expects one argument: file_path


### PR DESCRIPTION
I was having an issue using the updater.sh script on my Ubuntu 20.04 machine.

After some investigation I found at that the `download_file` function returns the path to the temporary file with a leading newline, which was produced by the curl command.

That resulted in error messages and the script not being able to determine the available version, e.g.:
```
sed: can't read 
/tmp/tmp.RBrbSv40X0: No such file or directory
Please observe the following information:
    Firefox profile:  <redacted>
    Available online: Not detected.
    Currently using:  * version: 97
```

The simple change in this PR fixed the problem for me and should not cause any side effects even on systems where this problem might not occur right now.