### PR TITLE
Making the silent flag suppress output

### DIFF
--- a/prefsCleaner.sh
+++ b/prefsCleaner.sh
@@ -20,7 +20,7 @@ cd "$(dirname "${sfp}")"
 fQuit() {
 	## change directory back to the original working directory
 	cd "${currdir}"
-	[ "$1" -eq 0 ] && echo -e "\n$2" || echo -e "\n$2" >&2
+	[ "$1" -ne 0 ] && echo -e "\n$2" >&2
 	exit $1
 }
 
@@ -71,11 +71,20 @@ fStart() {
 	fFF_check
 	bakfile="prefs.js.backup.$(date +"%Y-%m-%d_%H%M")"
 	mv prefs.js "${bakfile}" || fQuit 1 "Operation aborted.\nReason: Could not create backup file $bakfile"
-	echo -e "\nprefs.js backed up: $bakfile"
-	echo "Cleaning prefs.js..."
+	if [ "$1" -eq 1 ]; then
+		echo -e "\nprefs.js backed up: $bakfile"
+		echo "Cleaning prefs.js..."
+	fi
+
 	fClean "$bakfile"
-	fQuit 0 "All done!"
+
+	if [ "$1" -eq 1 ]; then
+		echo -e "\nAll done!"
+	fi
+		fQuit 0
 }
+
+[ "$1" == '-s' ] && fStart 0
 
 echo -e "\n\n"
 echo "                   ╔══════════════════════════╗"
@@ -88,12 +97,10 @@ echo "It will remove any entries from prefs.js that also exist in user.js."
 echo "This will allow inactive preferences to be reset to their default values."
 echo -e "\nThis Firefox profile shouldn't be in use during the process.\n"
 
-[ "$1" == '-s' ] && fStart
-
 select option in Start Help Exit; do
 	case $option in
 		Start)
-			fStart
+			fStart 1
 			;;
 		Help)
 			fUsage

--- a/updater.sh
+++ b/updater.sh
@@ -52,7 +52,8 @@ fi
 
 
 show_banner() {
-  echo -e "${BBLUE}
+  if [ "$CONFIRM" = 'yes' ]; then
+    echo -e "${BBLUE}
                 ############################################################################
                 ####                                                                    ####
                 ####                          arkenfox user.js                          ####
@@ -61,8 +62,9 @@ show_banner() {
                 ####            Updater for macOS and Linux by @overdodactyl            ####
                 ####                                                                    ####
                 ############################################################################"
-  echo -e "${NC}\n"
-  echo -e "Documentation for this script is available here: ${CYAN}https://github.com/arkenfox/user.js/wiki/5.1-Updater-[Options]#-maclinux${NC}\n"
+    echo -e "${NC}\n"
+    echo -e "Documentation for this script is available here: ${CYAN}https://github.com/arkenfox/user.js/wiki/5.1-Updater-[Options]#-maclinux${NC}\n"
+  fi
 }
 
 #########################
@@ -220,7 +222,9 @@ add_override() {
   if [ -f "$input" ]; then
     echo "" >> user.js
     cat "$input" >> user.js
-    echo -e "Status: ${GREEN}Override file appended:${NC} ${input}"
+    if [ "$CONFIRM" = 'yes' ]; then
+      echo -e "Status: ${GREEN}Override file appended:${NC} ${input}"
+    fi
   elif [ -d "$input" ]; then
     SAVEIFS=$IFS
     IFS=$'\n\b' # Set IFS
@@ -244,12 +248,12 @@ update_userjs() {
   declare -r newfile="$(download_file 'https://raw.githubusercontent.com/arkenfox/user.js/master/user.js')"
   [ -z "${newfile}" ] && echo -e "${RED}Error! Could not download user.js${NC}" && return 1 # check if download failed
 
-  echo -e "Please observe the following information:
-    Firefox profile:  ${ORANGE}$(pwd)${NC}
-    Available online: ${ORANGE}$(get_userjs_version "$newfile")${NC}
-    Currently using:  ${ORANGE}$(get_userjs_version user.js)${NC}\n\n"
-
   if [ "$CONFIRM" = 'yes' ]; then
+    echo -e "Please observe the following information:
+      Firefox profile:  ${ORANGE}$(pwd)${NC}
+      Available online: ${ORANGE}$(get_userjs_version "$newfile")${NC}
+      Currently using:  ${ORANGE}$(get_userjs_version user.js)${NC}\n\n"
+
     echo -e "This script will update to the latest user.js file and append any custom configurations from user-overrides.js. ${RED}Continue Y/N? ${NC}"
     read -p "" -n 1 -r
     echo -e "\n"
@@ -273,11 +277,15 @@ update_userjs() {
   cp user.js "$bakname" &>/dev/null
 
   mv "${newfile}" user.js
-  echo -e "Status: ${GREEN}user.js has been backed up and replaced with the latest version!${NC}"
+  if [ "$CONFIRM" = 'yes' ]; then
+    echo -e "Status: ${GREEN}user.js has been backed up and replaced with the latest version!${NC}"
+  fi
 
   if [ "$ESR" = true ]; then
     sed -e 's/\/\* \(ESR[0-9]\{2,\}\.x still uses all.*\)/\/\/ \1/' user.js > user.js.tmp && mv user.js.tmp user.js
-    echo -e "Status: ${GREEN}ESR related preferences have been activated!${NC}"
+    if [ "$CONFIRM" = 'yes' ]; then
+      echo -e "Status: ${GREEN}ESR related preferences have been activated!${NC}"
+    fi
   fi
 
   # apply overrides


### PR DESCRIPTION
The `-s` flag now suppresses output if no errors occur. This is useful for updating in scripts.