### PR TITLE
prefsCleaner.sh: Remove unnecessary chdir calls

### DIFF
--- a/prefsCleaner.sh
+++ b/prefsCleaner.sh
@@ -6,20 +6,8 @@
 
 ## special thanks to @overdodactyl and @earthlng for a few snippets that I stol..*cough* borrowed from the updater.sh
 
-currdir=$(pwd)
-
-## get the full path of this script (readlink for Linux, greadlink for Mac with coreutils installed)
-sfp=$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null)
-
-## fallback for Macs without coreutils
-if [ -z "$sfp" ]; then sfp=${BASH_SOURCE[0]}; fi
-
-## change directory to the Firefox profile directory
-cd "$(dirname "${sfp}")"
-
 fQuit() {
 	## change directory back to the original working directory
-	cd "${currdir}"
 	[ "$1" -eq 0 ] && echo -e "\n$2" || echo -e "\n$2" >&2
 	exit $1
 }


### PR DESCRIPTION
The `prefsCleaner.sh` script chdir()'s to the script's directory on
execution, which isn't necessary at all, and also means that has to
reside within the Firefox profile directory, rather than being callable
directly from the Git clone.

`updater.sh` has the same "problem", but honours the `-p` switch to let
the working directory be overridden.

This patch removes the unnecessary code, such that the `prefsCleaner.sh`
script works on `./user.js`.

Signed-off-by: martin f. krafft <madduck@madduck.net>