### PR TITLE
updater.sh: rewrite in POSIX sh

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -35,11 +35,11 @@ read_yn() {
 
 usage() {
     cat << EOF
-Usage: updater.sh [options] [PROFILE]
+usage: updater.sh [options] [<profile>]
 
 Update the user.js file and append custom configuration.
 
-Options:
+options:
     -e  Activate ESR preferences
     -f  Don't prompt for confirmation
     -h  Show this help message
@@ -91,7 +91,7 @@ if [ "$1" ]; then
     if [ -d "$1" ]; then
         dir="$1"
     else
-        die "'$1' isn't a valid directory"
+        die "'$1': no such directory"
     fi
 fi
 
@@ -99,7 +99,7 @@ fi
 pmt_yn 'Update user.js and append custom configuration from user-overrides.js?' \
     || exit 0
 
-[ "$dir" ] || dir="$(readlink -f "$0" | sed -E 's/\/[^\/]*$//')"
+[ "$dir" ] || dir="$(echo "$0" | sed -E 's/\/[^\/]*$//')"
 cd "$dir" || die "Couldn't change directory to '$dir', aborting."
 
 # Assume that a valid firefox profile directory has a prefs.js file

--- a/updater.sh
+++ b/updater.sh
@@ -1,390 +1,149 @@
-#!/usr/bin/env bash
+#!/bin/sh -fe
 
-## arkenfox user.js updater for macOS and Linux
+# arkenfox user.js updater for UNIX-like systems
 
-## version: 3.4
-## Author: Pat Johnson (@overdodactyl)
-## Additional contributors: @earthlng, @ema-pe, @claustromaniac
-
-## DON'T GO HIGHER THAN VERSION x.9 !! ( because of ASCII comparison in update_updater() )
-
-readonly CURRDIR=$(pwd)
-
-SCRIPT_FILE=$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || greadlink -f "${BASH_SOURCE[0]}" 2>/dev/null)
-[ -z "$SCRIPT_FILE" ] && SCRIPT_FILE=${BASH_SOURCE[0]}
-readonly SCRIPT_DIR=$(dirname "${SCRIPT_FILE}")
-
-
-#########################
-#    Base variables     #
-#########################
-
-# Colors used for printing
-RED='\033[0;31m'
-BLUE='\033[0;34m'
-BBLUE='\033[1;34m'
-GREEN='\033[0;32m'
-ORANGE='\033[0;33m'
-CYAN='\033[0;36m'
-NC='\033[0m' # No Color
-
-# Argument defaults
-UPDATE='check'
-CONFIRM='yes'
-OVERRIDE='user-overrides.js'
-BACKUP='multiple'
-COMPARE=false
-SKIPOVERRIDE=false
-VIEW=false
-PROFILE_PATH=false
-ESR=false
-
-# Download method priority: curl -> wget
-DOWNLOAD_METHOD=''
-if command -v curl >/dev/null; then
-  DOWNLOAD_METHOD='curl --max-redirs 3 -so'
-elif command -v wget >/dev/null; then
-  DOWNLOAD_METHOD='wget --max-redirect 3 --quiet -O'
-else
-  echo -e "${RED}This script requires curl or wget.\nProcess aborted${NC}"
-  exit 1
-fi
-
-
-show_banner() {
-  echo -e "${BBLUE}
-                ############################################################################
-                ####                                                                    ####
-                ####                          arkenfox user.js                          ####
-                ####       Hardening the Privacy and Security Settings of Firefox       ####
-                ####           Maintained by @Thorin-Oakenpants and @earthlng           ####
-                ####            Updater for macOS and Linux by @overdodactyl            ####
-                ####                                                                    ####
-                ############################################################################"
-  echo -e "${NC}\n"
-  echo -e "Documentation for this script is available here: ${CYAN}https://github.com/arkenfox/user.js/wiki/5.1-Updater-[Options]#-maclinux${NC}\n"
+die() {
+    printf "${red}!! %s${nc}\n" "$*"
+    exit 1
 }
 
-#########################
-#      Arguments        #
-#########################
+log() {
+    printf "${cya}-> ${nc}%s\n" "$*"
+}
+
+war_yn() {
+    [ "$prompt" -eq 0 ] && return 0
+    printf "${yel}%s${nc} [Y/n] " "$*"
+    read_yn
+    return $?
+}
+
+pmt_yn() {
+    [ "$prompt" -eq 0 ] && return 0
+    printf "${cya}%s${nc} [Y/n] " "$*"
+    read_yn
+    return $?
+}
+
+read_yn() {
+    read -r tmp
+    case "$tmp" in
+        [Nn]*) return 1 ;;
+        *)     return 0 ;;
+    esac
+}
 
 usage() {
-  echo
-  echo -e "${BLUE}Usage: $0 [-bcdehlnrsuv] [-p PROFILE] [-o OVERRIDE]${NC}" 1>&2  # Echo usage string to standard error
-  echo -e "
-Optional Arguments:
-    -h           Show this help message and exit.
-    -p PROFILE   Path to your Firefox profile (if different than the dir of this script)
-                 IMPORTANT: If the path contains spaces, wrap the entire argument in quotes.
-    -l           Choose your Firefox profile from a list
-    -u           Update updater.sh and execute silently.  Do not seek confirmation.
-    -d           Do not look for updates to updater.sh.
-    -s           Silently update user.js.  Do not seek confirmation.
-    -b           Only keep one backup of each file.
-    -c           Create a diff file comparing old and new user.js within userjs_diffs.
-    -o OVERRIDE  Filename or path to overrides file (if different than user-overrides.js).
-                 If used with -p, paths should be relative to PROFILE or absolute paths
-                 If given a directory, all files inside will be appended recursively.
-                 You can pass multiple files or directories by passing a comma separated list.
-                     Note: If a directory is given, only files inside ending in the extension .js are appended
-                     IMPORTANT: Do not add spaces between files/paths.  Ex: -o file1.js,file2.js,dir1
-                     IMPORTANT: If any file/path contains spaces, wrap the entire argument in quotes.
-                         Ex: -o \"override folder\"
-    -n           Do not append any overrides, even if user-overrides.js exists.
-    -v           Open the resulting user.js file.
-    -r           Only download user.js to a temporary file and open it.
-    -e           Activate ESR related preferences."
-  echo
-  exit 1
+    cat << EOF
+Usage: updater.sh [options] [PROFILE]
+
+Update the user.js file and append custom configuration.
+
+Options:
+    -e  Activate ESR preferences
+    -f  Don't prompt for confirmation
+    -h  Show this help message
+    -n  Don't append user overrides
+EOF
 }
 
-#########################
-#     File Handling     #
-#########################
+# Define color escape sequences
+red='\033[31m'
+yel='\033[33m'
+cya='\033[36m'
+nc='\033[m'
 
-download_file() { # expects URL as argument ($1)
-  declare -r tf=$(mktemp)
+# more variables
+esr=0
+prompt=1
+overrides=1
+cmd_get=
 
-  $DOWNLOAD_METHOD "${tf}" "$1" &>/dev/null && echo "$tf" || echo '' # return the temp-filename or empty string on error
-}
 
-open_file() { # expects one argument: file_path
-  if [ "$(uname)" == 'Darwin' ]; then
-    open "$1"
-  elif [ "$(uname -s | cut -c -5)" == "Linux" ]; then
-    xdg-open "$1"
-  else
-    echo -e "${RED}Error: Sorry, opening files is not supported for your OS.${NC}"
-  fi
-}
+####################
+#       Main       #
+####################
 
-readIniFile() { # expects one argument: absolute path of profiles.ini
-  declare -r inifile="$1"
-
-  # tempIni will contain: [ProfileX], Name=, IsRelative= and Path= (and Default= if present) of the only (if) or the selected (else) profile
-  if [ "$(grep -c '^\[Profile' "${inifile}")" -eq "1" ]; then ### only 1 profile found
-    tempIni="$(grep '^\[Profile' -A 4 "${inifile}")"
-  else
-    echo -e "Profiles found:\n––––––––––––––––––––––––––––––"
-    ## cmd-substitution to strip trailing newlines and in quotes to keep internal ones:
-    echo "$(grep --color=never -E 'Default=[^1]|\[Profile[0-9]*\]|Name=|Path=|^$' "${inifile}")"
-    echo '––––––––––––––––––––––––––––––'
-    read -p 'Select the profile number ( 0 for Profile0, 1 for Profile1, etc ) : ' -r
-    echo -e "\n"
-    if [[ $REPLY =~ ^(0|[1-9][0-9]*)$ ]]; then
-      tempIni="$(grep "^\[Profile${REPLY}" -A 4 "${inifile}")" || {
-        echo -e "${RED}Profile${REPLY} does not exist!${NC}" && exit 1
-      }
-    else
-      echo -e "${RED}Invalid selection!${NC}" && exit 1
-    fi
-  fi
-
-  # extracting 0 or 1 from the "IsRelative=" line
-  declare -r pathisrel=$(sed -n 's/^IsRelative=\([01]\)$/\1/p' <<< "${tempIni}")
-
-  # extracting only the path itself, excluding "Path="
-  PROFILE_PATH=$(sed -n 's/^Path=\(.*\)$/\1/p' <<< "${tempIni}")
-  # update global variable if path is relative
-  [[ ${pathisrel} == "1" ]] && PROFILE_PATH="$(dirname "${inifile}")/${PROFILE_PATH}"
-}
-
-getProfilePath() {
-  declare -r f1=~/Library/Application\ Support/Firefox/profiles.ini
-  declare -r f2=~/.mozilla/firefox/profiles.ini
-
-  if [ "$PROFILE_PATH" = false ]; then
-    PROFILE_PATH="$SCRIPT_DIR"
-  elif [ "$PROFILE_PATH" = 'list' ]; then
-    if [[ -f "$f1" ]]; then
-      readIniFile "$f1" # updates PROFILE_PATH or exits on error
-    elif [[ -f "$f2" ]]; then
-      readIniFile "$f2"
-    else
-      echo -e "${RED}Error: Sorry, -l is not supported for your OS${NC}"
-      exit 1
-    fi
-  #else
-    # PROFILE_PATH already set by user with -p
-  fi
-}
-
-#########################
-#   Update updater.sh   #
-#########################
-
-# Returns the version number of a updater.sh file
-get_updater_version() {
-  echo "$(sed -n '5 s/.*[[:blank:]]\([[:digit:]]*\.[[:digit:]]*\)/\1/p' "$1")"
-}
-
-# Update updater.sh
-# Default: Check for update, if available, ask user if they want to execute it
-# Args:
-#   -d: New version will not be looked for and update will not occur
-#   -u: Check for update, if available, execute without asking
-update_updater() {
-  [ "$UPDATE" = 'no' ] && return 0 # User signified not to check for updates
-
-  declare -r tmpfile="$(download_file 'https://raw.githubusercontent.com/arkenfox/user.js/master/updater.sh')"
-  [ -z "${tmpfile}" ] && echo -e "${RED}Error! Could not download updater.sh${NC}" && return 1 # check if download failed
-
-  if [[ $(get_updater_version "$SCRIPT_FILE") < $(get_updater_version "${tmpfile}") ]]; then
-    if [ "$UPDATE" = 'check' ]; then
-      echo -e "There is a newer version of updater.sh available. ${RED}Update and execute Y/N?${NC}"
-      read -p "" -n 1 -r
-      echo -e "\n\n"
-      [[ $REPLY =~ ^[Nn]$ ]] && return 0 # Update available, but user chooses not to update
-    fi
-  else
-    return 0 # No update available
-  fi
-  mv "${tmpfile}" "$SCRIPT_FILE"
-  chmod u+x "$SCRIPT_FILE"
-  "$SCRIPT_FILE" "$@" -d
-  exit 0
-}
-
-#########################
-#    Update user.js     #
-#########################
-
-# Returns version number of a user.js file
-get_userjs_version() {
-  [ -e "$1" ] && echo "$(sed -n '4p' "$1")" || echo "Not detected."
-}
-
-add_override() {
-  input=$1
-  if [ -f "$input" ]; then
-    echo "" >> user.js
-    cat "$input" >> user.js
-    echo -e "Status: ${GREEN}Override file appended:${NC} ${input}"
-  elif [ -d "$input" ]; then
-    SAVEIFS=$IFS
-    IFS=$'\n\b' # Set IFS
-    FILES="${input}"/*.js
-    for f in $FILES
-    do
-      add_override "$f"
-    done
-    IFS=$SAVEIFS # restore $IFS
-  else
-    echo -e "${ORANGE}Warning: Could not find override file:${NC} ${input}"
-  fi
-}
-
-remove_comments() { # expects 2 arguments: from-file and to-file
-  sed -e '/^\/\*.*\*\/[[:space:]]*$/d' -e '/^\/\*/,/\*\//d' -e 's|^[[:space:]]*//.*$||' -e '/^[[:space:]]*$/d' -e 's|);[[:space:]]*//.*|);|' "$1" > "$2"
-}
-
-# Applies latest version of user.js and any custom overrides
-update_userjs() {
-  declare -r newfile="$(download_file 'https://raw.githubusercontent.com/arkenfox/user.js/master/user.js')"
-  [ -z "${newfile}" ] && echo -e "${RED}Error! Could not download user.js${NC}" && return 1 # check if download failed
-
-  echo -e "Please observe the following information:
-    Firefox profile:  ${ORANGE}$(pwd)${NC}
-    Available online: ${ORANGE}$(get_userjs_version "$newfile")${NC}
-    Currently using:  ${ORANGE}$(get_userjs_version user.js)${NC}\n\n"
-
-  if [ "$CONFIRM" = 'yes' ]; then
-    echo -e "This script will update to the latest user.js file and append any custom configurations from user-overrides.js. ${RED}Continue Y/N? ${NC}"
-    read -p "" -n 1 -r
-    echo -e "\n"
-    if [[ $REPLY =~ ^[Nn]$ ]]; then
-      echo -e "${RED}Process aborted${NC}"
-      rm "$newfile"
-      return 1
-    fi
-  fi
-
-  # Copy a version of user.js to diffs folder for later comparison
-  if [ "$COMPARE" = true ]; then
-    mkdir -p userjs_diffs
-    cp user.js userjs_diffs/past_user.js &>/dev/null
-  fi
-
-  # backup user.js
-  mkdir -p userjs_backups
-  local bakname="userjs_backups/user.js.backup.$(date +"%Y-%m-%d_%H%M")"
-  [ "$BACKUP" = 'single' ] && bakname='userjs_backups/user.js.backup'
-  cp user.js "$bakname" &>/dev/null
-
-  mv "${newfile}" user.js
-  echo -e "Status: ${GREEN}user.js has been backed up and replaced with the latest version!${NC}"
-
-  if [ "$ESR" = true ]; then
-    sed -e 's/\/\* \(ESR[0-9]\{2,\}\.x still uses all.*\)/\/\/ \1/' user.js > user.js.tmp && mv user.js.tmp user.js
-    echo -e "Status: ${GREEN}ESR related preferences have been activated!${NC}"
-  fi
-
-  # apply overrides
-  if [ "$SKIPOVERRIDE" = false ]; then
-    while IFS=',' read -ra FILES; do
-      for FILE in "${FILES[@]}"; do
-        add_override "$FILE"
-      done
-    done <<< "$OVERRIDE"
-  fi
-
-  # create diff
-  if [ "$COMPARE" = true ]; then
-    pastuserjs='userjs_diffs/past_user.js'
-    past_nocomments='userjs_diffs/past_userjs.txt'
-    current_nocomments='userjs_diffs/current_userjs.txt'
-
-    remove_comments "$pastuserjs" "$past_nocomments"
-    remove_comments user.js "$current_nocomments"
-
-    diffname="userjs_diffs/diff_$(date +"%Y-%m-%d_%H%M").txt"
-    diff=$(diff -w -B -U 0 "$past_nocomments" "$current_nocomments")
-    if [ -n "$diff" ]; then
-      echo "$diff" > "$diffname"
-      echo -e "Status: ${GREEN}A diff file was created:${NC} ${PWD}/${diffname}"
-    else
-      echo -e "Warning: ${ORANGE}Your new user.js file appears to be identical.  No diff file was created.${NC}"
-      [ "$BACKUP" = 'multiple' ] && rm "$bakname" &>/dev/null
-    fi
-    rm "$past_nocomments" "$current_nocomments" "$pastuserjs" &>/dev/null
-  fi
-
-  [ "$VIEW" = true ] && open_file "${PWD}/user.js"
-}
-
-#########################
-#        Execute        #
-#########################
-
-if [ $# != 0 ]; then
-  # Display usage if first argument is -help or --help
-  if [ "$1" = '--help' ] || [ "$1" = '-help' ]; then
-    usage
-  else
-    while getopts ":hp:ludsno:bcvre" opt; do
-      case $opt in
-        h)
-          usage
-          ;;
-        p)
-          PROFILE_PATH=${OPTARG}
-          ;;
-        l)
-          PROFILE_PATH='list'
-          ;;
-        u)
-          UPDATE='yes'
-          ;;
-        d)
-          UPDATE='no'
-          ;;
-        s)
-          CONFIRM='no'
-          ;;
-        n)
-          SKIPOVERRIDE=true
-          ;;
-        o)
-          OVERRIDE=${OPTARG}
-          ;;
-        b)
-          BACKUP='single'
-          ;;
-        c)
-          COMPARE=true
-          ;;
-        v)
-          VIEW=true
-          ;;
-        e)
-          ESR=true
-          ;;
-        r)
-          tfile="$(download_file 'https://raw.githubusercontent.com/arkenfox/user.js/master/user.js')"
-          [ -z "${tfile}" ] && echo -e "${RED}Error! Could not download user.js${NC}" && exit 1 # check if download failed
-          mv "$tfile" "${tfile}.js"
-          echo -e "${ORANGE}Warning: user.js was saved to temporary file ${tfile}.js${NC}"
-          open_file "${tfile}.js"
-          exit 0
-          ;;
-        \?)
-          echo -e "${RED}\n Error! Invalid option: -$OPTARG${NC}" >&2
-          usage
-          ;;
-        :)
-          echo -e "${RED}Error! Option -$OPTARG requires an argument.${NC}" >&2
-          exit 2
-          ;;
-      esac
-    done
-  fi
+# set command for downloading user.js
+if command -v curl >/dev/null; then
+    cmd_get='curl -Lso'
+elif command -v wget >/dev/null; then
+    cmd_get='wget -qO'
+else
+    die This script needs curl or wget, aborting.
 fi
 
-show_banner
-update_updater "$@"
+# Parse commandline options
+while getopts :hefn opt; do
+    case "$opt" in
+        e) esr=1 ;;
+        f) prompt=0 ;;
+        h) usage; exit 0 ;;
+        n) overrides=0 ;;
+        :) die "Option -$OPTARG requires argument." ;;
+        ?) die "Invalid option -$OPTARG" ;;
+        *) exit ;;
+    esac
+done
 
-getProfilePath # updates PROFILE_PATH or exits on error
-cd "$PROFILE_PATH" && update_userjs
+shift "$((OPTIND - 1))"
+if [ "$1" ]; then
+    if [ -d "$1" ]; then
+        dir="$1"
+    else
+        die "'$1' isn't a valid directory"
+    fi
+fi
 
-cd "$CURRDIR"
+# Prompt user for confirmation
+pmt_yn 'Update user.js and append custom configuration from user-overrides.js?' \
+    || exit 0
+
+[ "$dir" ] || dir="$(readlink -f "$0" | sed -E 's/\/[^\/]*$//')"
+cd "$dir" || die "Couldn't change directory to '$dir', aborting."
+
+# Assume that a valid firefox profile directory has a prefs.js file
+if ! [ -f "prefs.js" ]; then
+    # Prompt if the user wants to continue, even if it doesn't look like a
+    # firefox profile directory.
+    war_yn "'$PWD' doesn't look like a firefox profile directory, continue anyway?" \
+        || exit 0
+fi
+
+# Create backup of user.js
+if [ -f user.js ]; then
+    # use ISO 8601 date format, instead of making up our own.
+    bak="userjs_backups/user.js.$(date "+%Y-%m-%dT%H:%M%z")"
+    log Creating a backup of user.js in "$bak"
+    mkdir -p userjs_backups 2>/dev/null
+
+    cp -f user.js "$bak" 2>/dev/null ||
+        die "Couldn't create a backup of user.js, aborting."
+fi
+
+# Download user.js
+log Fetching new version of user.js
+$cmd_get user.js \
+    https://raw.githubusercontent.com/arkenfox/user.js/master/user.js \
+        || die "Couldn't download user.js, aborting."
+
+# ESR preferences
+if [ "$esr" = 1 ]; then
+    log Applying ESR preferences
+    # shellcheck disable=SC2015 
+    sed '/\/\* ESR91\.x still uses all the following prefs/s/^\/\*/\/\//' user.js > _ \
+        && mv _ user.js || die "Couldn't apply ESR preferences"
+fi
+
+# Apply overrides
+if [ "$overrides" -eq 1 ]; then
+    if [ -f user-overrides.js ]; then
+        log Applying overrides in user-overrides.js
+        echo >> user.js
+        cat user-overrides.js >> user.js
+    else
+        log user-overrides.js not found, skipping overriding user preferences...
+    fi
+fi
+
+log Updating user.js finished successfully!


### PR DESCRIPTION
I rewrote updater.sh in POSIX sh, so that bash is no longer a dependency. I've omitted a lot of flags either because I haven't gotten around to implementing them, or I'm skeptical of their necessity.

All the most important features (except for updating the script itself) have been implemented.

Missing features (that I know of)
---------------------------------
- [ ] choose firefox profile from a list
- [ ] update updater.sh (planned)
- [ ] one user.js backup only
- [ ] create a diff file
- [ ] custom overrides file or directory
- [ ] open user.js
- [ ] download user.js to a temporary file

Changes
-------
- ISO date format for backup files
- Prompt for confirmation, if no prefs.js file is found (to prevent accidentally runnning in non-profile directory)
- More concise & consistent output.

If there is interest in merging this, I'm willing to add more features from the original bash script before doing so.