### PR TITLE
make updater.sh check explicitly for Y/y instead of N/n

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -2,9 +2,9 @@
 
 ## arkenfox user.js updater for macOS and Linux
 
-## version: 3.4
+## version: 3.5
 ## Author: Pat Johnson (@overdodactyl)
-## Additional contributors: @earthlng, @ema-pe, @claustromaniac
+## Additional contributors: @earthlng, @ema-pe, @claustromaniac, @infinitewarp
 
 ## DON'T GO HIGHER THAN VERSION x.9 !! ( because of ASCII comparison in update_updater() )
 
@@ -195,7 +195,7 @@ update_updater() {
       echo -e "There is a newer version of updater.sh available. ${RED}Update and execute Y/N?${NC}"
       read -p "" -n 1 -r
       echo -e "\n\n"
-      [[ $REPLY =~ ^[Nn]$ ]] && return 0 # Update available, but user chooses not to update
+      ! [[ $REPLY =~ ^[Yy]$ ]] && return 0 # Update available, but user chooses not to update
     fi
   else
     return 0 # No update available
@@ -253,7 +253,7 @@ update_userjs() {
     echo -e "This script will update to the latest user.js file and append any custom configurations from user-overrides.js. ${RED}Continue Y/N? ${NC}"
     read -p "" -n 1 -r
     echo -e "\n"
-    if [[ $REPLY =~ ^[Nn]$ ]]; then
+    if ! [[ $REPLY =~ ^[Yy]$ ]]; then
       echo -e "${RED}Process aborted${NC}"
       rm "$newfile"
       return 1


### PR DESCRIPTION
Hello user.js folks! 👋 Long time listener, first time caller here.

I recently used the `updater.sh` script to update one of my profiles, but I fat-fingered my reply to the confirmation prompt with a `T` instead of a `Y`, and it proceeded to update anyway. This seems bad! Confirmation prompts like this should err on the side of caution and only perform a destructive operation if the user explicitly enters an affirmative `Y`/`y` response. (Yes, I'm aware that the script makes a backup file, but still…)

I dug into the code and realized that you're doing the opposite: `updater.sh` only aborts upon receiving a `N`/`n` response. *Any* other input appears to be treated as a destructive `Y`/`y`. Yikes!

So, I swapped the logic around. It now treats only `Y`/`y` as an affirmative response.

Tested using `q` and then `y` in this demo of your version versus mine:

[![asciicast](https://asciinema.org/a/509667.svg)](https://asciinema.org/a/509667)