### PR TITLE
Back up prefs.js to `prefsjs_backups` directory

### DIFF
--- a/prefsCleaner.sh
+++ b/prefsCleaner.sh
@@ -69,7 +69,8 @@ fStart() {
 	fi
 
 	fFF_check
-	bakfile="prefs.js.backup.$(date +"%Y-%m-%d_%H%M")"
+	mkdir -p prefsjs_backups
+	bakfile="prefsjs_backups/prefs.js.backup.$(date +"%Y-%m-%d_%H%M")"
 	mv prefs.js "${bakfile}" || fQuit 1 "Operation aborted.\nReason: Could not create backup file $bakfile"
 	echo -e "\nprefs.js backed up: $bakfile"
 	echo "Cleaning prefs.js..."


### PR DESCRIPTION
`updater.sh` creates a `userjs_backups` directory and `user.js` backups are saved to it:

https://github.com/arkenfox/user.js/blob/996881aef184246a011ac29382e91d634cda7b65/updater.sh#L270-L273

Thought it would be nice to have the same behavior with `prefsCleaner.sh`, it unclutters the Firefox profile directory.