### PR TITLE
Prevent leaking theme accent

### DIFF
--- a/user.js
+++ b/user.js
@@ -920,11 +920,13 @@ user_pref("browser.startup.blankWindow", false);
  * [SETTING] General>Language and Appearance>Fonts and Colors>Colors>Use system colors ***/
 user_pref("browser.display.use_system_colors", false); // [DEFAULT false NON-WINDOWS]
 /* 4511: enforce non-native widget theme
+ * additionally disable use of theme accent
  * Security: removes/reduces system API calls, e.g. win32k API [1]
  * Fingerprinting: provides a uniform look and feel across platforms [2]
  * [1] https://bugzilla.mozilla.org/1381938
  * [2] https://bugzilla.mozilla.org/1411425 ***/
 user_pref("widget.non-native-theme.enabled", true); // [DEFAULT: true]
+user_pref("widget.non-native-theme.use-theme-accent", false);
 /* 4512: enforce links targeting new windows to open in a new tab instead
  * 1=most recent window or tab, 2=new window, 3=new tab
  * Stops malicious window sizes and some screen resolution leaks.


### PR DESCRIPTION
Tested working on Android/Mull 103 and Fedora/GNOME/Firefox 102

Reported here: https://forum.f-droid.org/t/websites-can-know-android-accent-color/19133