### PR TITLE
Format date and time consistently.

### DIFF
--- a/prefsCleaner.bat
+++ b/prefsCleaner.bat
@@ -31,8 +31,11 @@ IF NOT EXIST "prefs.js" (CALL :abort "prefs.js not found in the current director
 CALL :strlenCheck
 CALL :FFcheck
 CALL :message "Backing up prefs.js..."
-SET "_time=%time: =0%"
-COPY /B /V /Y prefs.js "prefs-backup-%date:/=-%_%_time::=.%.js"
+FOR /F "usebackq tokens=1,2 delims==" %%i IN (`wmic os get LocalDateTime /VALUE 2^>NUL`) DO IF '.%%i.'=='.LocalDateTime.' SET ldt=%%j
+SET ldt=%ldt:~0,4%-%ldt:~4,2%-%ldt:~6,2%_%ldt:~8,2%%ldt:~10,2%
+REM For ISO format use:
+REM SET ldt=%ldt:~0,4%%ldt:~4,2%%ldt:~6,2%T%ldt:~8,2%%ldt:~10,2%%ldt:~12,6%
+COPY /B /V /Y prefs.js "prefs-backup-%ldt%.js"
 CALL :message "Cleaning prefs.js..."
 CALL :cleanup
 CALL :message "All done!"

--- a/prefsCleaner.bat
+++ b/prefsCleaner.bat
@@ -30,12 +30,12 @@ IF NOT EXIST "user.js" (CALL :abort "user.js not found in the current directory.
 IF NOT EXIST "prefs.js" (CALL :abort "prefs.js not found in the current directory." 30)
 CALL :strlenCheck
 CALL :FFcheck
+
 CALL :message "Backing up prefs.js..."
 FOR /F "usebackq tokens=1,2 delims==" %%i IN (`wmic os get LocalDateTime /VALUE 2^>NUL`) DO IF '.%%i.'=='.LocalDateTime.' SET ldt=%%j
-SET ldt=%ldt:~0,4%-%ldt:~4,2%-%ldt:~6,2%_%ldt:~8,2%%ldt:~10,2%
-REM For ISO format use:
-REM SET ldt=%ldt:~0,4%%ldt:~4,2%%ldt:~6,2%T%ldt:~8,2%%ldt:~10,2%%ldt:~12,6%
+SET ldt=%ldt:~0,8%_%ldt:~8,6%
 COPY /B /V /Y prefs.js "prefs-backup-%ldt%.js"
+
 CALL :message "Cleaning prefs.js..."
 CALL :cleanup
 CALL :message "All done!"

--- a/prefsCleaner.bat
+++ b/prefsCleaner.bat
@@ -3,7 +3,7 @@ TITLE prefs.js cleaner
 
 REM ### prefs.js cleaner for Windows
 REM ## author: @claustromaniac
-REM ## version: 2.4
+REM ## version: 2.5
 
 CD /D "%~dp0"
 
@@ -13,7 +13,7 @@ ECHO:
 ECHO                 ########################################
 ECHO                 ####  prefs.js cleaner for Windows  ####
 ECHO                 ####        by claustromaniac       ####
-ECHO                 ####              v2.4              ####
+ECHO                 ####              v2.5              ####
 ECHO                 ########################################
 ECHO:
 CALL :message "This script should be run from your Firefox profile directory."

--- a/updater.bat
+++ b/updater.bat
@@ -178,9 +178,7 @@ IF EXIST user.js.new (
 			MOVE /Y user.js user.js.bak >nul
 		) ELSE (
 			FOR /F "usebackq tokens=1,2 delims==" %%i IN (`wmic os get LocalDateTime /VALUE 2^>NUL`) DO IF '.%%i.'=='.LocalDateTime.' SET ldt=%%j
-			SET ldt=%ldt:~0,4%-%ldt:~4,2%-%ldt:~6,2%_%ldt:~8,2%%ldt:~10,2%
-			REM For ISO format use: 
-			REM SET ldt=%ldt:~0,4%%ldt:~4,2%%ldt:~6,2%T%ldt:~8,2%%ldt:~10,2%%ldt:~12,6%
+			SET ldt=%ldt:~0,8%_%ldt:~8,6%
 			MOVE /Y user.js "user-backup-%ldt%.js" >nul
 		)
 		REN user.js.new user.js

--- a/updater.bat
+++ b/updater.bat
@@ -3,10 +3,10 @@ TITLE arkenfox user.js updater
 
 REM ## arkenfox user.js updater for Windows
 REM ## author: @claustromaniac
-REM ## version: 4.16
+REM ## version: 4.17
 REM ## instructions: https://github.com/arkenfox/user.js/wiki/5.1-Updater-[Options]#-windows
 
-SET v=4.15
+SET v=4.17
 
 VERIFY ON
 CD /D "%~dp0"
@@ -177,8 +177,11 @@ IF EXIST user.js.new (
 		IF DEFINED _singlebackup (
 			MOVE /Y user.js user.js.bak >nul
 		) ELSE (
-			SET "_time=!time: =0!"
-			MOVE /Y user.js "user-backup-!date:/=-!_!_time::=.!.js" >nul
+			FOR /F "usebackq tokens=1,2 delims==" %%i IN (`wmic os get LocalDateTime /VALUE 2^>NUL`) DO IF '.%%i.'=='.LocalDateTime.' SET ldt=%%j
+			SET ldt=%ldt:~0,4%-%ldt:~4,2%-%ldt:~6,2%_%ldt:~8,2%%ldt:~10,2%
+			REM For ISO format use: 
+			REM SET ldt=%ldt:~0,4%%ldt:~4,2%%ldt:~6,2%T%ldt:~8,2%%ldt:~10,2%%ldt:~12,6%
+			MOVE /Y user.js "user-backup-%ldt%.js" >nul
 		)
 		REN user.js.new user.js
 		CALL :message "Update complete."


### PR DESCRIPTION
Currently, in the .bat files, the date and time used for renaming backup copies of files are formatted in a way that is locale dependent.  For example, in my locale calling

```cmd
echo %date%_%time%
```

outputs `sre. 09. 11. 2022_13:07:47,71`.
This does not sort nicely and in addition includes unneeded information, such as the weekday and the hundredths of second.

In this pull request, I explicitly requested the format of date and time, which translates into consistent filenames of backup files. I used [the method suggested by an answer on StackOverflow](https://stackoverflow.com/a/203116/4341436). The format was chosen to mirror `updater.sh` , while I also included the ISO format as an alternative in a remark.

I also bumped the version of the `updater.bat` (but not `prefsCleaner.bat`) and `SET v=4.17` accordingly, which was lagging one version number behind.