### PR TITLE
Improve Usability by Clarifying Desired Action

### DIFF
--- a/prefsCleaner.sh
+++ b/prefsCleaner.sh
@@ -88,6 +88,7 @@ echo -e "\nThis script should be run from your Firefox profile directory.\n"
 echo "It will remove any entries from prefs.js that also exist in user.js."
 echo "This will allow inactive preferences to be reset to their default values."
 echo -e "\nThis Firefox profile shouldn't be in use during the process.\n"
+echo -e "\nIn order to proceed, select a command below by entering its corresponding number.\n"
 
 [ "$1" == '-s' ] && fStart
 


### PR DESCRIPTION
Running`prefsCleaner.sh` prompts the user for command selection before continuing. However, it fails to tell the user how to proceed and instead just displays the following options:
`1) Start
2) Help
3) Exit`
Common sense would dictate that the user should enter one of the commands to proceed, but the script only accepts the numerical input. For example `Start` and `start` fail to resume the script, but `1` does.

After a few tries, the user should be able to figure out how to proceed, but appending this short line (or equivalent) increases usability, specifically for inexperienced users. It's not a huge improvement, but it's a small improvement in clarity that could save a few keystrokes.