### PR TITLE
prefsCleaner.bat: add -unattended flag

### DIFF
--- a/prefsCleaner.bat
+++ b/prefsCleaner.bat
@@ -7,6 +7,8 @@ REM ## version: 2.5
 
 CD /D "%~dp0"
 
+GOTO parse
+
 :begin
 ECHO:
 ECHO:
@@ -22,10 +24,12 @@ CALL :message "This will allow inactive preferences to be reset to their default
 ECHO   This Firefox profile shouldn't be in use during the process.
 CALL :message ""
 TIMEOUT 1 /nobreak >nul
-CHOICE /C SHE /N /M "Start [S] Help [H] Exit [E]"
-CLS
-IF ERRORLEVEL 3 (EXIT /B)
-IF ERRORLEVEL 2 (GOTO :showhelp)
+IF NOT DEFINED _ua (
+	CHOICE /C SHE /N /M "Start [S] Help [H] Exit [E]"
+	CLS
+	IF ERRORLEVEL 3 (EXIT /B)
+	IF ERRORLEVEL 2 (GOTO :showhelp)
+)
 IF NOT EXIST "user.js" (CALL :abort "user.js not found in the current directory." 30)
 IF NOT EXIST "prefs.js" (CALL :abort "prefs.js not found in the current directory." 30)
 CALL :strlenCheck
@@ -48,6 +52,14 @@ REM ########## Abort Function ###########
 CALL :message %1
 TIMEOUT %~2 >nul
 EXIT
+
+REM ########## Parse Function ###########
+:parse
+IF "%~1"=="" (GOTO endparse)
+IF /I "%~1"=="-unattended" (SET _ua=1)
+:endparse
+GOTO begin
+
 REM ########## Message Function #########
 :message
 ECHO:

--- a/prefsCleaner.bat
+++ b/prefsCleaner.bat
@@ -53,7 +53,6 @@ REM ########## Abort Function ###########
 CALL :message %1
 TIMEOUT %~2 >nul
 EXIT
-
 REM ########## Message Function #########
 :message
 ECHO:

--- a/prefsCleaner.bat
+++ b/prefsCleaner.bat
@@ -3,11 +3,11 @@ TITLE prefs.js cleaner
 
 REM ### prefs.js cleaner for Windows
 REM ## author: @claustromaniac
-REM ## version: 2.5
+REM ## version: 2.6
 
 CD /D "%~dp0"
 
-GOTO parse
+IF /I "%~1"=="-unattended" (SET _ua=1)
 
 :begin
 ECHO:
@@ -15,7 +15,7 @@ ECHO:
 ECHO                 ########################################
 ECHO                 ####  prefs.js cleaner for Windows  ####
 ECHO                 ####        by claustromaniac       ####
-ECHO                 ####              v2.5              ####
+ECHO                 ####              v2.6              ####
 ECHO                 ########################################
 ECHO:
 CALL :message "This script should be run from your Firefox profile directory."
@@ -24,6 +24,7 @@ CALL :message "This will allow inactive preferences to be reset to their default
 ECHO   This Firefox profile shouldn't be in use during the process.
 CALL :message ""
 TIMEOUT 1 /nobreak >nul
+
 IF NOT DEFINED _ua (
 	CHOICE /C SHE /N /M "Start [S] Help [H] Exit [E]"
 	CLS
@@ -52,13 +53,6 @@ REM ########## Abort Function ###########
 CALL :message %1
 TIMEOUT %~2 >nul
 EXIT
-
-REM ########## Parse Function ###########
-:parse
-IF "%~1"=="" (GOTO endparse)
-IF /I "%~1"=="-unattended" (SET _ua=1)
-:endparse
-GOTO begin
 
 REM ########## Message Function #########
 :message


### PR DESCRIPTION
Usage:
  prefsCleaner.bat -unattended

Skips the prompt for user input and proceeds when -unattended is specified. If omitted, default behaviour is unchanged.

Code taken from updater.bat for consistency.

Please review this PR closely as I'm not fluent in batch scripting. The revised script appears to function properly with and without -unattended, but I'm not aware of common pitfalls.

Signed-off-by: Keith Harrison <keithh@protonmail.com>