### PR TITLE
Disable Firefox start page sponsored sites "contile"

### DIFF
--- a/user.js
+++ b/user.js
@@ -181,8 +181,8 @@ user_pref("app.normandy.api_url", "");
 
 /** CRASH REPORTS ***/
 /* 0350: disable Crash Reports ***/
-user_pref("breakpad.reportURL", "");
-user_pref("browser.tabs.crashReporting.sendReport", false); // [FF44+]
+user_pref("breakpad.reportURL", "https://www.mozilla.org/legal/privacy/firefox.html#crash-reporter");
+user_pref("browser.tabs.crashReporting.sendReport", true); // [FF44+]
    // user_pref("browser.crashReports.unsubmittedCheck.enabled", false); // [FF51+] [DEFAULT: false]
 /* 0351: enforce no submission of backlogged Crash Reports [FF58+]
  * [SETTING] Privacy & Security>Firefox Data Collection & Use>Allow Firefox to send backlogged crash reports  ***/

--- a/user.js
+++ b/user.js
@@ -363,6 +363,10 @@ user_pref("browser.formfill.enable", false);
  * [4] https://earthlng.github.io/testpages/visited_links.html (see github wiki APPENDIX A on how to use)
  * [5] https://lcamtuf.blogspot.com/2016/08/css-mix-blend-mode-is-bad-for-keeping.html ***/
    // user_pref("layout.css.visited_links_enabled", false);
+/* 0821: disable connection to sponsored sites on Firefox start page
+ * [1] https://www.kuketz-blog.de/mozilla-firefox-datensendeverhalten-desktop-version-browser-check-teil20/ ***/
+user_pref("browser.topsites.contile.enabled", false);
+
 
 /*** [SECTION 0900]: PASSWORDS
    [1] https://support.mozilla.org/kb/use-primary-password-protect-stored-logins-and-pas


### PR DESCRIPTION
The start page can actually be useful. If users may reenable it, these sites would automatically make connections

https://www.kuketz-blog.de/mozilla-firefox-datensendeverhalten-desktop-version-browser-check-teil20/