### PR TITLE
updater.sh/prefsCleaner.sh: Check for root and abort

### DIFF
--- a/prefsCleaner.sh
+++ b/prefsCleaner.sh
@@ -15,7 +15,7 @@ if [ "${EUID:-$(id -u)}" -eq 0 ]; then
 elif [ -n "$(find ./ -user 0 -o -group 0)" ]; then
 	printf 'It looks like this script was previously run with elevated privileges,
 you will need to change ownership of the following files to your user:\n'
-	find ./ -user 0 -o -group 0
+	find . -user 0 -o -group 0
 	exit 1
 fi
 

--- a/prefsCleaner.sh
+++ b/prefsCleaner.sh
@@ -2,11 +2,22 @@
 
 ## prefs.js cleaner for Linux/Mac
 ## author: @claustromaniac
-## version: 1.6
+## version: 1.7
 
 ## special thanks to @overdodactyl and @earthlng for a few snippets that I stol..*cough* borrowed from the updater.sh
 
 ## DON'T GO HIGHER THAN VERSION x.9 !! ( because of ASCII comparison in update_prefsCleaner() )
+
+# Check if running as root and if any files have the owner/group as root/wheel.
+if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+	printf 'You should not run this with elevated privileges (such as with doas/sudo).\n'
+	exit 1
+elif [ -n "$(find ./ -user 0 -o -group 0)" ]; then
+	printf 'It looks like this script was previously run with elevated privileges,
+you will need to change ownership of the following files to your user:\n'
+	find ./ -user 0 -o -group 0
+	exit 1
+fi
 
 readonly CURRDIR=$(pwd)
 
@@ -138,7 +149,7 @@ echo -e "\n\n"
 echo "                   ╔══════════════════════════╗"
 echo "                   ║     prefs.js cleaner     ║"
 echo "                   ║    by claustromaniac     ║"
-echo "                   ║           v1.6           ║"
+echo "                   ║           v1.7           ║"
 echo "                   ╚══════════════════════════╝"
 echo -e "\nThis script should be run from your Firefox profile directory.\n"
 echo "It will remove any entries from prefs.js that also exist in user.js."

--- a/prefsCleaner.sh
+++ b/prefsCleaner.sh
@@ -10,7 +10,7 @@
 
 # Check if running as root and if any files have the owner/group as root/wheel.
 if [ "${EUID:-"$(id -u)"}" -eq 0 ]; then
-	printf 'You should not run this with elevated privileges (such as with doas/sudo).\n'
+	printf 'You shouldn't run this with elevated privileges (such as with doas/sudo).\n'
 	exit 1
 elif [ -n "$(find ./ -user 0 -o -group 0)" ]; then
 	printf 'It looks like this script was previously run with elevated privileges,

--- a/prefsCleaner.sh
+++ b/prefsCleaner.sh
@@ -9,7 +9,7 @@
 ## DON'T GO HIGHER THAN VERSION x.9 !! ( because of ASCII comparison in update_prefsCleaner() )
 
 # Check if running as root and if any files have the owner/group as root/wheel.
-if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+if [ "${EUID:-"$(id -u)"}" -eq 0 ]; then
 	printf 'You should not run this with elevated privileges (such as with doas/sudo).\n'
 	exit 1
 elif [ -n "$(find ./ -user 0 -o -group 0)" ]; then

--- a/updater.sh
+++ b/updater.sh
@@ -15,7 +15,7 @@ if [ "${EUID:-$(id -u)}" -eq 0 ]; then
 elif [ -n "$(find ./ -user 0 -o -group 0)" ]; then
 	printf 'It looks like this script was previously run with elevated privileges,
 you will need to change ownership of the following files to your user:\n'
-	find ./ -user 0 -o -group 0
+	find . -user 0 -o -group 0
 	exit 1
 fi
 

--- a/updater.sh
+++ b/updater.sh
@@ -2,11 +2,22 @@
 
 ## arkenfox user.js updater for macOS and Linux
 
-## version: 3.5
+## version: 3.6
 ## Author: Pat Johnson (@overdodactyl)
 ## Additional contributors: @earthlng, @ema-pe, @claustromaniac, @infinitewarp
 
 ## DON'T GO HIGHER THAN VERSION x.9 !! ( because of ASCII comparison in update_updater() )
+
+# Check if running as root and if any files have the owner/group as root/wheel.
+if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+	printf 'You should not run this with elevated privileges (such as with doas/sudo).\n'
+	exit 1
+elif [ -n "$(find ./ -user 0 -o -group 0)" ]; then
+	printf 'It looks like this script was previously run with elevated privileges,
+you will need to change ownership of the following files to your user:\n'
+	find ./ -user 0 -o -group 0
+	exit 1
+fi
 
 readonly CURRDIR=$(pwd)
 

--- a/updater.sh
+++ b/updater.sh
@@ -10,7 +10,7 @@
 
 # Check if running as root and if any files have the owner/group as root/wheel.
 if [ "${EUID:-"$(id -u)"}" -eq 0 ]; then
-	printf 'You should not run this with elevated privileges (such as with doas/sudo).\n'
+	printf 'You shouldn't run this with elevated privileges (such as with doas/sudo).\n'
 	exit 1
 elif [ -n "$(find ./ -user 0 -o -group 0)" ]; then
 	printf 'It looks like this script was previously run with elevated privileges,

--- a/updater.sh
+++ b/updater.sh
@@ -9,7 +9,7 @@
 ## DON'T GO HIGHER THAN VERSION x.9 !! ( because of ASCII comparison in update_updater() )
 
 # Check if running as root and if any files have the owner/group as root/wheel.
-if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+if [ "${EUID:-"$(id -u)"}" -eq 0 ]; then
 	printf 'You should not run this with elevated privileges (such as with doas/sudo).\n'
 	exit 1
 elif [ -n "$(find ./ -user 0 -o -group 0)" ]; then


### PR DESCRIPTION
Check if running as root and if any files have the owner/group as root|wheel. Abort on both.

Should (hopefully) prevent stuff like: https://github.com/arkenfox/user.js/issues/1587
Discussion: https://github.com/arkenfox/user.js/pull/1595

This does not attempt to correct the permissions, just notify the user
and abort.

If I followed https://github.com/arkenfox/user.js/issues/1587 right.
The original person didn't realize that it appended and subsequent
people tried to run with elevated privileges.  This should at least fix
the second.