### PR TITLE
POSIX friendly printing

### DIFF
--- a/updater.sh
+++ b/updater.sh
@@ -57,8 +57,9 @@ printf_color() {
 }
 
 printf_color_newline() {
-  printf_color "$@"
-  echo
+  PROVIDED_COLOR="$1"
+  shift
+  printf "${PROVIDED_COLOR}%s${NC}\n" "$*"
 }
 
 warn() {
@@ -80,6 +81,7 @@ else
   err 'Process aborted'
   exit 1
 fi
+
 
 show_banner() {
   printf_color_newline "${BBLUE}" '

--- a/updater.sh
+++ b/updater.sh
@@ -149,7 +149,7 @@ open_file() { # expects one argument: file_path
   elif [ "$(uname -s | cut -c -5)" == "Linux" ]; then
     xdg-open "$1"
   else
-    err 'Error: Sorry opening files is not supported for your OS.'
+    err 'Error: Sorry, opening files is not supported for your OS.'
   fi
 }
 
@@ -258,7 +258,6 @@ add_override() {
   if [ -f "$input" ]; then
     echo "" >> user.js
     cat "$input" >> user.js
-
     printf '%s' 'Status: '
     printf_color "${GREEN}" 'Override file appended:'
     echo " ${input}"


### PR DESCRIPTION
Hey, I noticed that there have been a number of discussions and pull requests about moving `updater.sh` away from bash toward POSIX compliance (#1641 being one example). I'm opening a simple pull request to test the waters and gauge interest before I attempt to write something more thorough.

As a side note, if the maintainers are open to a pull request replacing `{updater,prefsCleaner}.{sh,bat}` with a Perl implementation, I could see myself doing this. I see a lot of ways that programs like these could benefit from being written in a more structured language. 

One benefit is actually related to portability: all of what I've seen so far could be handled by Perl's included modules and built-ins. This does require a Perl installation, but the current script requires bash + curl/wget which may not be a given either (for instance, this is less likely to be the case on the BSDs). 

Please let me know if there are any changes you would like me to make or if you need more details on something. I had considered adding an `exit 1` to `err()`, but I noticed the exit codes aren't consistent throughout `updater.sh` so I omitted that.
