### PR TITLE
Disabled block_mozAddonManager, very outdated

### DIFF
--- a/user.js
+++ b/user.js
@@ -761,8 +761,10 @@ user_pref("privacy.window.maxInnerWidth", 1600);
 user_pref("privacy.window.maxInnerHeight", 900);
 /* 4503: disable mozAddonManager Web API [FF57+]
  * [NOTE] To allow extensions to work on AMO, you also need 2662
- * [1] https://bugzilla.mozilla.org/buglist.cgi?bug_id=1384330,1406795,1415644,1453988 ***/
-user_pref("privacy.resistFingerprinting.block_mozAddonManager", true);
+ * [1] https://bugzilla.mozilla.org/buglist.cgi?bug_id=1384330: FIXED in 57.0
+ * [2] 1406795,1415644 allowed addons Access to AMO and install malicious addons, FIXED in 60.0
+ * [3] 1453988 forbids Addons to run on AMO, intentional against malicious addons***/
+// user_pref("privacy.resistFingerprinting.block_mozAddonManager", true);
 /* 4504: enable RFP letterboxing [FF67+]
  * Dynamically resizes the inner window by applying margins in stepped ranges [2]
  * If you use the dimension pref, then it will only apply those resolutions.


### PR DESCRIPTION
All the linked issues are fixed since v60.0 (!)

It is intentional that Addons cannot run on AMO, to avoid addons injecting malicious .xpi downloads and tricking users into installing ANYTHING.

I am wondering if there are more of these extremely outdated settings...