### PR TITLE
Workaround for console font being changed to raster for people with Consolas as default

### DIFF
--- a/prefsCleaner.bat
+++ b/prefsCleaner.bat
@@ -1,6 +1,6 @@
 @ECHO OFF & SETLOCAL DisableDelayedExpansion
 TITLE prefs.js cleaner
-
+chcp 437>nul
 REM ### prefs.js cleaner for Windows
 REM ## author: @claustromaniac
 REM ## version: 2.7

--- a/updater.bat
+++ b/updater.bat
@@ -1,6 +1,6 @@
 @ECHO OFF & SETLOCAL EnableDelayedExpansion
 TITLE arkenfox user.js updater
-
+chcp 437>nul
 REM ## arkenfox user.js updater for Windows
 REM ## author: @claustromaniac
 REM ## version: 4.19


### PR DESCRIPTION
Running the scripts with Consolas set as default will change the font to the much less readable raster - this is a workaround.
https://github.com/Microsoft/WSL/issues/2050