### PR TITLE
Add missing -command argument in powershell call

### DIFF
--- a/prefsCleaner.bat
+++ b/prefsCleaner.bat
@@ -37,7 +37,7 @@ CALL :strlenCheck
 CALL :FFcheck
 
 CALL :message "Backing up prefs.js..."
-FOR /F "delims=" %%# IN ('powershell get-date -format "{yyyyMMdd_HHmmss}"') DO @SET ldt=%%#
+FOR /F "delims=" %%# IN ('powershell -command get-date -format "{yyyyMMdd_HHmmss}"') DO @SET ldt=%%#
 COPY /B /V /Y prefs.js "prefs-backup-%ldt%.js"
 
 CALL :message "Cleaning prefs.js..."

--- a/updater.bat
+++ b/updater.bat
@@ -177,7 +177,7 @@ IF EXIST user.js.new (
 		IF DEFINED _singlebackup (
 			MOVE /Y user.js user.js.bak >nul
 		) ELSE (
-			FOR /F "delims=" %%# IN ('powershell get-date -format "{yyyyMMdd_HHmmss}"') DO @SET ldt=%%#
+			FOR /F "delims=" %%# IN ('powershell -command get-date -format "{yyyyMMdd_HHmmss}"') DO @SET ldt=%%#
 			MOVE /Y user.js "user-backup-!ldt!.js" >nul
 		)
 		REN user.js.new user.js


### PR DESCRIPTION
it seems like at least with powershell core - you need the `-command` argument passed to powershell to execute a built-in function.
currently, the backup filename is not `prefs-backup-(date/time).js` but `prefs-backup-All parameters are case-insensitive.js`, because this is the output of the powershell command
```
The argument 'get-date' is not recognized as the name of a script file. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
...
All parameters are case-insensitive.
```