### PR TITLE
Turn off an advertising reporting feature

### DIFF
--- a/user.js
+++ b/user.js
@@ -1223,6 +1223,9 @@ user_pref("toolkit.telemetry.firstShutdownPing.enabled", false); // [FF57+]
 user_pref("toolkit.telemetry.coverage.opt-out", true); // [HIDDEN PREF]
 user_pref("toolkit.coverage.opt-out", true); // [FF64+] [HIDDEN PREF]
 user_pref("toolkit.coverage.endpoint.base", "");
+/* 8504: disable advertising reporting
+ * [1] https://www.privacyguides.org/articles/2024/07/14/mozilla-disappoints-us-yet-again-2/ ***/
+user_pref("dom.private-attribution.submission.enabled", false);
 
 /*** [SECTION 9000]: NON-PROJECT RELATED ***/
 user_pref("_user.js.parrot", "9000 syntax error: the parrot's cashed in 'is chips!");


### PR DESCRIPTION
The "dom.private-attribution.submission.enabled" preference controls a feature called "Privacy-Preserving Attribution" co-developed by Mozilla and Meta. This feature creates privacy risks that normal product telemetry does not.